### PR TITLE
Use sha.js instead of crypto-browserify

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@ var shasum = require('shasum')
 shasum(string || buffer || object)
 ```
 
-Oh yeah, it works in the browser too, with 
-[crypto-browserify](https://npmjs.org/package/crypto-browserify)
+Oh yeah, it works in the browser too, with [browserify](https://npmjs.org/package/browserify)
 
 ## License
 

--- a/browser.js
+++ b/browser.js
@@ -1,0 +1,13 @@
+
+var createHash = require('sha.js')
+var Buffer = require('buffer').Buffer
+var stringify = require('json-stable-stringify')
+
+module.exports = function hash (str, alg, format) {
+  str = 'string' === typeof str ? str
+    : Buffer.isBuffer(str) ? str
+    : stringify(str)
+  return createHash(alg || 'sha1')
+    .update(str, Buffer.isBuffer(str) ? null : 'utf8').digest(format || 'hex')
+}
+

--- a/package.json
+++ b/package.json
@@ -7,12 +7,16 @@
     "url": "git://github.com/dominictarr/shasum.git"
   },
   "dependencies": {
-    "json-stable-stringify": "~0.0.0"
+    "json-stable-stringify": "~0.0.0",
+    "sha.js": "~2.3.0"
   },
   "devDependencies": {
   },
+  "browser": {
+    "./index.js": "./browser.js"
+  },
   "scripts": {
-    "test": "set -e; for t in test/*.js; do node $t; done"
+    "test": "node test/index.js && node test/index.js browser"
   },
   "author": "'Dominic Tarr' <dominic.tarr@gmail.com> (http://dominictarr.com)",
   "license": "MIT"  

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,5 @@
 var equal = require('assert').equal
-var hash = require('..')
+var hash = require(process.argv[2] === 'browser' ? '../browser.js' : '..')
 
 
 equal(hash('abc'),  'a9993e364706816aba3e25717850c26c9cd0d89d')


### PR DESCRIPTION
This still passes all the tests and makes the library about 14KB minified and Gzipped (including all dependencies) rather than about 200KB minified and Gzipped.  Without this change, the library is
practically unusable for anyone who doesn’t expect to need a significant proportion of the rest of crypto-browserify.